### PR TITLE
Fix typo in const string

### DIFF
--- a/src/Spryker/Zed/AclMerchantPortal/Business/Generator/AclMerchantPortalGenerator.php
+++ b/src/Spryker/Zed/AclMerchantPortal/Business/Generator/AclMerchantPortalGenerator.php
@@ -17,7 +17,7 @@ class AclMerchantPortalGenerator implements AclMerchantPortalGeneratorInterface
     /**
      * @var string
      */
-    protected const KEY_MERCHANT_PORTAL = 'MerchantPortral';
+    protected const KEY_MERCHANT_PORTAL = 'MerchantPortal';
 
     /**
      * @var \Spryker\Zed\AclMerchantPortal\AclMerchantPortalConfig


### PR DESCRIPTION
## PR Description

The generated user group names all have a typo in the suffix MerchantPort**r**al.
This will be fixed with this PR

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
